### PR TITLE
fix: update generate.js - exclude period (.) from linkify

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -109,7 +109,7 @@ function linkify(text) {
 	return text
 	  .toLowerCase()
 	  .replace(/\s/g, '-')
-	  .replace(/[^0-9a-z.-]/g, '');
+	  .replace(/[^0-9a-z-]/g, '');
 }
 
 var parentLevel = function (hashCount, tabCount) {


### PR DESCRIPTION
Hi again,
 Ran into an issue where period is included in header links when it shouldn't be.

Incorrect:

```md
- [This vs. That](#this-vs.-that)

## This vs. That
```

Correct:

```md
- [This vs. That](#this-vs-that)

## This vs. That
```


Per below. "any other punctuation is removed" including period.

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#section-links